### PR TITLE
fix: correct test imports to match actual exports

### DIFF
--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -8,7 +8,7 @@ from typer.testing import CliRunner
 import json
 import os
 
-from pwndoc_mcp_server.cli import app, version_callback
+from pwndoc_mcp_server.cli import app
 
 
 @pytest.fixture

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -11,10 +11,10 @@ from unittest.mock import patch, MagicMock
 
 from pwndoc_mcp_server.config import (
     Config,
+    DEFAULT_CONFIG_DIR,
+    DEFAULT_CONFIG_FILE,
     load_config,
     save_config,
-    get_config_path,
-    DEFAULT_CONFIG,
 )
 
 

--- a/python/tests/test_logging.py
+++ b/python/tests/test_logging.py
@@ -9,9 +9,8 @@ import tempfile
 from pathlib import Path
 
 from pwndoc_mcp_server.logging_config import (
-    setup_logging,
     get_logger,
-    LogLevel,
+    setup_logging,
 )
 
 

--- a/python/tests/test_server.py
+++ b/python/tests/test_server.py
@@ -6,11 +6,7 @@ import pytest
 import json
 from unittest.mock import AsyncMock, patch, MagicMock
 
-from pwndoc_mcp_server.server import (
-    PwnDocMCPServer,
-    create_server,
-    TOOL_DEFINITIONS,
-)
+from pwndoc_mcp_server.server import PwnDocMCPServer
 from pwndoc_mcp_server.config import Config
 
 


### PR DESCRIPTION
- Remove non-existent version_callback from test_cli.py
- Replace get_config_path and DEFAULT_CONFIG with actual exports in test_config.py
- Remove non-existent LogLevel from test_logging.py
- Remove non-existent create_server and TOOL_DEFINITIONS from test_server.py
- All tests should now import correctly

# Pull Request

## Description

Brief description of changes and motivation.

Fixes # (issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

### Test Configuration

- **OS**: 
- **Python Version**: 
- **PwnDoc Version**: 

### Tests Performed

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

### Test Commands

```bash
# Commands used to test
pytest tests/
pwndoc-mcp test
```

## Documentation

- [ ] README updated (if needed)
- [ ] CHANGELOG updated
- [ ] Docstrings added/updated
- [ ] Documentation files updated (if needed)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information for reviewers.
