### PR TITLE
Fix Unicode logging on Windows

### DIFF
--- a/python/src/pwndoc_mcp_server/logging_config.py
+++ b/python/src/pwndoc_mcp_server/logging_config.py
@@ -197,7 +197,17 @@ def setup_logging(
 
     # Console handler (if enabled)
     if console:
-        console_handler = logging.StreamHandler(sys.stderr)
+        # On Windows, wrap stderr with UTF-8 encoding to handle Unicode
+        if sys.platform == "win32":
+            import io
+
+            # Wrap stderr with UTF-8 encoding and error handling
+            stderr_stream = io.TextIOWrapper(
+                sys.stderr.buffer, encoding="utf-8", errors="replace", line_buffering=True
+            )
+            console_handler = logging.StreamHandler(stderr_stream)
+        else:
+            console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setFormatter(formatter)
         root_logger.addHandler(console_handler)
 
@@ -210,11 +220,12 @@ def setup_logging(
         if max_bytes is None:
             max_bytes = max_size_mb * 1024 * 1024
 
-        # Use rotating file handler
+        # Use rotating file handler with UTF-8 encoding
         file_handler = logging.handlers.RotatingFileHandler(
             log_path,
             maxBytes=max_bytes,
             backupCount=backup_count,
+            encoding="utf-8",
         )
 
         # Always use non-colored formatter for files


### PR DESCRIPTION
Fixed UnicodeEncodeError on Windows by configuring proper UTF-8 encoding:

- Wrap sys.stderr with UTF-8 TextIOWrapper on Windows to handle Unicode characters (Japanese, Arabic, Chinese) that can't be encoded with cp1252
- Add explicit UTF-8 encoding to RotatingFileHandler
- Use errors='replace' for graceful fallback on encoding issues

This fixes test_unicode_logging failure on Windows while maintaining backward compatibility with Linux/macOS.

Fixes #test_logging.py::TestLoggingIntegration::test_unicode_logging

# Pull Request

## Description

Brief description of changes and motivation.

Fixes # (issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

### Test Configuration

- **OS**: 
- **Python Version**: 
- **PwnDoc Version**: 

### Tests Performed

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

### Test Commands

```bash
# Commands used to test
pytest tests/
pwndoc-mcp test
```

## Documentation

- [ ] README updated (if needed)
- [ ] CHANGELOG updated
- [ ] Docstrings added/updated
- [ ] Documentation files updated (if needed)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information for reviewers.
