### PR TITLE
Fix Docker build by including README.md

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 WORKDIR /app
 
 # Install dependencies
-COPY pyproject.toml .
+COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir .
 
 # Copy source


### PR DESCRIPTION
The pyproject.toml references README.md for package metadata, so it needs to be copied before running pip install.

Added README.md to the COPY step before the pip install command to fix the build error:
  OSError: Readme file does not exist: README.md

This ensures the package metadata can be properly generated during the Docker build process.

# Pull Request

## Description

Brief description of changes and motivation.

Fixes # (issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

### Test Configuration

- **OS**: 
- **Python Version**: 
- **PwnDoc Version**: 

### Tests Performed

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

### Test Commands

```bash
# Commands used to test
pytest tests/
pwndoc-mcp test
```

## Documentation

- [ ] README updated (if needed)
- [ ] CHANGELOG updated
- [ ] Docstrings added/updated
- [ ] Documentation files updated (if needed)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information for reviewers.
