### PR TITLE
Fix Native CI/CD: Update macOS runner to macos-15

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -25,7 +25,7 @@ jobs:
           - os: ubuntu-latest
             name: linux-x64
             artifact: pwndoc-mcp-linux-x64
-          - os: macos-13
+          - os: macos-15
             name: macos-x64
             artifact: pwndoc-mcp-macos-x64
           - os: macos-latest


### PR DESCRIPTION
Replaced deprecated macos-13 runner with macos-15 to fix the build error: "The macOS-13 based runner images are now retired"

This ensures the macOS x64 build will run successfully on the latest supported GitHub Actions runner.

# Pull Request

## Description

Brief description of changes and motivation.

Fixes # (issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

### Test Configuration

- **OS**: 
- **Python Version**: 
- **PwnDoc Version**: 

### Tests Performed

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

### Test Commands

```bash
# Commands used to test
pytest tests/
pwndoc-mcp test
```

## Documentation

- [ ] README updated (if needed)
- [ ] CHANGELOG updated
- [ ] Docstrings added/updated
- [ ] Documentation files updated (if needed)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information for reviewers.
