### PR TITLE
Release 1.0.1 for CLI packaging fix

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pwndoc-mcp-server"
-version = "1.0.0.post1"
+version = "1.0.1"
 description = "Model Context Protocol server for PwnDoc penetration testing documentation"
 readme = "README.md"
 license = "MIT"
@@ -39,6 +39,8 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.25.0",
+    "rich>=13.0.0",
+    "typer>=0.9.0",
     "pyyaml>=6.0",
 ]
 
@@ -65,7 +67,7 @@ dev = [
 ]
 
 [project.scripts]
-pwndoc-mcp = "pwndoc_mcp_server.cli:app"
+pwndoc-mcp = "pwndoc_mcp_server.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/walidfaour/pwndoc-mcp-server"


### PR DESCRIPTION
## Summary
- bump package version to 1.0.1 to publish the CLI dependency and entry-point fix

## Testing
- not run (network restrictions prevent installing build dependencies here)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481c8c4900832e991105266a5f43bf)