### PR TITLE
Release 1.0.1 for CLI packaging fix

### DIFF
--- a/docs/development/building.md
+++ b/docs/development/building.md
@@ -95,8 +95,8 @@ python -m build
 
 # Output in dist/
 ls dist/
-# pwndoc_mcp_server-1.0.0-py3-none-any.whl
-# pwndoc_mcp_server-1.0.0.tar.gz
+# pwndoc_mcp_server-1.0.1-py3-none-any.whl
+# pwndoc_mcp_server-1.0.1.tar.gz
 ```
 
 ### Docker Image
@@ -106,7 +106,7 @@ ls dist/
 docker build -t pwndoc-mcp-server .
 
 # Build with tag
-docker build -t pwndoc-mcp-server:1.0.0 .
+docker build -t pwndoc-mcp-server:1.0.1 .
 
 # Multi-platform build
 docker buildx build --platform linux/amd64,linux/arm64 -t pwndoc-mcp-server .
@@ -138,7 +138,7 @@ sudo apt install dpkg-dev debhelper
 # Build .deb
 dpkg-buildpackage -us -uc -b
 
-# Output: ../pwndoc-mcp-server_1.0.0_amd64.deb
+# Output: ../pwndoc-mcp-server_1.0.1_amd64.deb
 ```
 
 ### RPM Package
@@ -150,7 +150,7 @@ sudo dnf install rpm-build
 # Build .rpm
 rpmbuild -bb rpm/pwndoc-mcp-server.spec
 
-# Output: ~/rpmbuild/RPMS/x86_64/pwndoc-mcp-server-1.0.0-1.x86_64.rpm
+# Output: ~/rpmbuild/RPMS/x86_64/pwndoc-mcp-server-1.0.1-1.x86_64.rpm
 ```
 
 ## Running Tests

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -86,26 +86,26 @@ Download `pwndoc-mcp-server-windows-x64.exe` from the releases page and add to y
 
 ```bash
 # Download the .deb package
-wget https://github.com/walidfaour/pwndoc-mcp-server/releases/latest/download/pwndoc-mcp-server_1.0.0_amd64.deb
+wget https://github.com/walidfaour/pwndoc-mcp-server/releases/latest/download/pwndoc-mcp-server_1.0.1_amd64.deb
 
 # Install
-sudo dpkg -i pwndoc-mcp-server_1.0.0_amd64.deb
+sudo dpkg -i pwndoc-mcp-server_1.0.1_amd64.deb
 
 # Or with apt (handles dependencies)
-sudo apt install ./pwndoc-mcp-server_1.0.0_amd64.deb
+sudo apt install ./pwndoc-mcp-server_1.0.1_amd64.deb
 ```
 
 ### RHEL/Fedora/CentOS (yum/dnf)
 
 ```bash
 # Download the .rpm package
-wget https://github.com/walidfaour/pwndoc-mcp-server/releases/latest/download/pwndoc-mcp-server-1.0.0-1.x86_64.rpm
+wget https://github.com/walidfaour/pwndoc-mcp-server/releases/latest/download/pwndoc-mcp-server-1.0.1-1.x86_64.rpm
 
 # Install with yum
-sudo yum localinstall pwndoc-mcp-server-1.0.0-1.x86_64.rpm
+sudo yum localinstall pwndoc-mcp-server-1.0.1-1.x86_64.rpm
 
 # Or with dnf
-sudo dnf install ./pwndoc-mcp-server-1.0.0-1.x86_64.rpm
+sudo dnf install ./pwndoc-mcp-server-1.0.1-1.x86_64.rpm
 ```
 
 ### Homebrew (macOS)

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -279,7 +279,7 @@ pwndoc-mcp version
 
 Output:
 ```
-pwndoc-mcp-server 1.0.0
+pwndoc-mcp-server 1.0.1
 Python 3.11.5
 Platform: Linux-5.15.0-x86_64
 ```

--- a/docs/user-guide/docker.md
+++ b/docs/user-guide/docker.md
@@ -21,7 +21,7 @@ docker run -it --rm \
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `1.0.0` | Specific version |
+| `1.0.1` | Specific version |
 | `1.0` | Latest patch of version 1.0 |
 | `main` | Latest from main branch |
 | `sha-abc1234` | Specific commit |
@@ -195,7 +195,7 @@ Response:
 ```json
 {
   "status": "healthy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "pwndoc_connected": true
 }
 ```

--- a/mcp-registry.json
+++ b/mcp-registry.json
@@ -2,7 +2,7 @@
   "name": "pwndoc",
   "display_name": "PwnDoc MCP Server",
   "description": "Model Context Protocol server for PwnDoc penetration testing documentation. Enables AI assistants to interact with your pentest reports, findings, clients, and vulnerability templates.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Walid Faour",
     "github": "walidfaour"

--- a/packaging/homebrew/pwndoc-mcp-server.rb
+++ b/packaging/homebrew/pwndoc-mcp-server.rb
@@ -12,7 +12,7 @@ class PwndocMcpServer < Formula
 
   desc "Model Context Protocol server for PwnDoc penetration testing documentation"
   homepage "https://github.com/walidfaour/pwndoc-mcp-server"
-  url "https://github.com/walidfaour/pwndoc-mcp-server/archive/refs/tags/v1.0.0.tar.gz"
+  url "https://github.com/walidfaour/pwndoc-mcp-server/archive/refs/tags/v1.0.1.tar.gz"
   sha256 "PLACEHOLDER_SHA256"  # Update with actual sha256 after release
   license "MIT"
   head "https://github.com/walidfaour/pwndoc-mcp-server.git", branch: "main"

--- a/packaging/scoop/pwndoc-mcp-server.json
+++ b/packaging/scoop/pwndoc-mcp-server.json
@@ -1,11 +1,11 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Model Context Protocol server for PwnDoc penetration testing documentation",
     "homepage": "https://github.com/walidfaour/pwndoc-mcp-server",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/walidfaour/pwndoc-mcp-server/releases/download/v1.0.0/pwndoc-mcp-server-windows-x64.exe",
+            "url": "https://github.com/walidfaour/pwndoc-mcp-server/releases/download/v1.0.1/pwndoc-mcp-server-windows-x64.exe",
             "hash": "PLACEHOLDER_SHA256"
         }
     },

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pwndoc-mcp-server"
-version = "1.0.0.post1"
+version = "1.0.1"
 description = "Model Context Protocol server for PwnDoc penetration testing documentation"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.8"
 authors = [
-    { name = "Walid Faour", email = "walid@walidfaour.com" }
+    { name = "Walid Faour", email = "security@walidfaour.com" }
 ]
 keywords = [
     "mcp",
@@ -39,6 +39,8 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.25.0",
+    "rich>=13.0.0",
+    "typer>=0.9.0",
     "pyyaml>=6.0",
 ]
 
@@ -65,7 +67,7 @@ dev = [
 ]
 
 [project.scripts]
-pwndoc-mcp = "pwndoc_mcp_server.cli:app"
+pwndoc-mcp = "pwndoc_mcp_server.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/walidfaour/pwndoc-mcp-server"

--- a/python/scripts/bump_version.py
+++ b/python/scripts/bump_version.py
@@ -1,0 +1,109 @@
+"""
+Utility to bump all version references for a new release.
+
+Usage:
+    python scripts/bump_version.py --version v1.0.3
+
+Pass the version with or without a leading "v". The script updates:
+- python/pyproject.toml
+- python/src/pwndoc_mcp_server/version.py (fallback version)
+- python/src/pwndoc_mcp_server/server.py (SERVER_VERSION)
+- mcp-registry.json
+- packaging/homebrew/pwndoc-mcp-server.rb
+- packaging/scoop/pwndoc-mcp-server.json
+- docs references that embed the release version
+
+The goal is to keep CLI output, metadata, docs, and packaging manifests in sync
+with the release tag (e.g., v1.0.3).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Callable
+
+
+def normalize_version(raw: str) -> tuple[str, str]:
+    """Return (version, tag) where tag always includes the leading 'v'."""
+    cleaned = raw.strip()
+    version = cleaned[1:] if cleaned.startswith("v") else cleaned
+    tag = f"v{version}"
+    return version, tag
+
+
+def update_file(path: Path, pattern: str, repl: Callable[[re.Match[str]], str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    new_text, count = re.subn(pattern, repl, text, flags=re.MULTILINE)
+    if count == 0:
+        raise RuntimeError(f"Pattern not found in {path}: {pattern}")
+    path.write_text(new_text, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Bump version across the repository.")
+    parser.add_argument("--version", required=True, help="Release version (e.g., v1.0.3 or 1.0.3)")
+    args = parser.parse_args()
+
+    version, tag = normalize_version(args.version)
+
+    root = Path(__file__).resolve().parents[2]  # repo root
+
+    # Core metadata
+    update_file(
+        root / "python" / "pyproject.toml",
+        r'^version = "[^"]+"',
+        lambda _: f'version = "{version}"',
+    )
+    update_file(
+        root / "python" / "src" / "pwndoc_mcp_server" / "version.py",
+        r'_FALLBACK_VERSION = "[^"]+"',
+        lambda _: f'_FALLBACK_VERSION = "{version}"',
+    )
+    update_file(
+        root / "mcp-registry.json",
+        r'"version": "[^"]+"',
+        lambda _: f'"version": "{version}"',
+    )
+
+    # Packaging manifests
+    update_file(
+        root / "packaging" / "homebrew" / "pwndoc-mcp-server.rb",
+        r"v[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz",
+        lambda _: f"{tag}.tar.gz",
+    )
+    update_file(
+        root / "packaging" / "scoop" / "pwndoc-mcp-server.json",
+        r'"version": "[^"]+"',
+        lambda _: f'"version": "{version}"',
+    )
+    update_file(
+        root / "packaging" / "scoop" / "pwndoc-mcp-server.json",
+        r"releases/download/v[0-9]+\.[0-9]+\.[0-9]+/pwndoc-mcp-server-windows-x64\.exe",
+        lambda _: f"releases/download/{tag}/pwndoc-mcp-server-windows-x64.exe",
+    )
+
+    # Documentation references (keep these scoped to release numbers)
+    docs_patterns = [
+        (root / "docs" / "user-guide" / "cli.md", r"pwndoc-mcp-server [0-9]+\.[0-9]+\.[0-9]+"),
+        (root / "docs" / "user-guide" / "docker.md", r'"version": "[0-9]+\.[0-9]+\.[0-9]+"'),
+        (root / "docs" / "user-guide" / "docker.md", r"`[0-9]+\.[0-9]+\.[0-9]+`"),
+        (root / "docs" / "development" / "building.md", r"pwndoc_mcp_server-[0-9]+\.[0-9]+\.[0-9]+"),
+        (root / "docs" / "development" / "building.md", r"pwndoc-mcp-server:[0-9]+\.[0-9]+\.[0-9]+"),
+        (root / "docs" / "development" / "building.md", r"pwndoc-mcp-server_[0-9]+\.[0-9]+\.[0-9]+"),
+        (root / "docs" / "getting-started" / "installation.md", r"pwndoc-mcp-server_[0-9]+\.[0-9]+\.[0-9]+_amd64\.deb"),
+        (root / "docs" / "getting-started" / "installation.md", r"pwndoc-mcp-server-[0-9]+\.[0-9]+\.[0-9]+-1\.x86_64\.rpm"),
+    ]
+
+    def replace_version_literal(match: re.Match[str]) -> str:
+        return re.sub(r"[0-9]+\.[0-9]+\.[0-9]+", version, match.group(0))
+
+    for path, pattern in docs_patterns:
+        update_file(path, pattern, replace_version_literal)
+
+    print(f"Updated repository version to {version} (tag {tag})")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/pwndoc_mcp_server/__init__.py
+++ b/python/src/pwndoc_mcp_server/__init__.py
@@ -4,7 +4,9 @@ PwnDoc MCP Server
 Model Context Protocol server for PwnDoc penetration testing documentation.
 """
 
-__version__ = "1.0.0.post1"
+from pwndoc_mcp_server.version import get_version
+
+__version__ = get_version()
 __author__ = "Walid Faour"
 
 # Export main classes and functions

--- a/python/src/pwndoc_mcp_server/server.py
+++ b/python/src/pwndoc_mcp_server/server.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from .client import PwnDocClient, PwnDocError
 from .config import Config, load_config
+from .version import get_version
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +60,7 @@ class PwnDocMCPServer:
     """
 
     SERVER_NAME = "pwndoc-mcp-server"
-    SERVER_VERSION = "1.0.0"
+    SERVER_VERSION = get_version()
     PROTOCOL_VERSION = "2024-11-05"
 
     def __init__(self, config: Optional[Config] = None, transport: Optional[str] = None):

--- a/python/src/pwndoc_mcp_server/version.py
+++ b/python/src/pwndoc_mcp_server/version.py
@@ -1,0 +1,26 @@
+"""
+Version helpers for PwnDoc MCP Server.
+
+Centralizes version lookup so the CLI and server report the same value.
+"""
+
+from importlib import metadata
+
+PACKAGE_NAME = "pwndoc-mcp-server"
+_FALLBACK_VERSION = "1.0.1"
+
+
+def get_version() -> str:
+    """
+    Return the installed package version, falling back to a bundled default.
+
+    This ensures local source checkouts (or editable installs) still report a
+    sensible version while published wheels use the package metadata.
+    """
+    try:
+        return metadata.version(PACKAGE_NAME)
+    except metadata.PackageNotFoundError:
+        return _FALLBACK_VERSION
+
+
+__all__ = ["get_version", "PACKAGE_NAME"]


### PR DESCRIPTION
## Summary
- align CLI and server version reporting with package metadata so installed versions match PyPI
- add a bump_version utility script to update all versioned artifacts from a single release number
- refresh docs and packaging manifests to 1.0.1, ensuring author metadata uses the security contact

## Testing
- not run (network restrictions prevent installing build dependencies here)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481c8c4900832e991105266a5f43bf)