### PR TITLE
Fix 'Full tool documentation' link to include /overview path

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ docker run -it --rm \
 
 > 💡 **Tip:** Use `pwndoc-mcp tools` to list all available tools with descriptions
 
-[Full tool documentation →](https://walidfaour.github.io/pwndoc-mcp-server/tools)
+[Full tool documentation →](https://walidfaour.github.io/pwndoc-mcp-server/tools/overview)
 
 ## 📖 Documentation
 


### PR DESCRIPTION
The link was pointing to /tools which returns 404. Updated to correct URL: /tools/overview

# Pull Request

## Description

Brief description of changes and motivation.

Fixes # (issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD changes
- [ ] Dependencies update

## Changes Made

- Change 1
- Change 2
- Change 3

## Testing

### Test Configuration

- **OS**: 
- **Python Version**: 
- **PwnDoc Version**: 

### Tests Performed

- [ ] Unit tests pass (`pytest`)
- [ ] Integration tests pass
- [ ] Manual testing performed
- [ ] New tests added for new functionality

### Test Commands

```bash
# Commands used to test
pytest tests/
pwndoc-mcp test
```

## Documentation

- [ ] README updated (if needed)
- [ ] CHANGELOG updated
- [ ] Docstrings added/updated
- [ ] Documentation files updated (if needed)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information for reviewers.
