### PR TITLE
Add custom fields support to findings documentation and server implementation

### DIFF
--- a/docs/tools/findings.md
+++ b/docs/tools/findings.md
@@ -83,6 +83,47 @@ Create a new finding in an audit.
 | `category` | string | No | Category |
 | `scope` | string | No | Affected scope/asset |
 | `references` | array | No | Reference URLs |
+| `customFields` | array | No | Custom fields values (see below) |
+
+### Custom Fields Parameter
+
+The `customFields` parameter allows you to set values for custom fields defined in PwnDoc. Each item in the array must have:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `customField` | string | The custom field ID (get from `list_custom_fields`) |
+| `text` | string or array | Value for the field. String for `input`/`select`/`text` types, array for `select-multiple`/`checkbox` types |
+
+**Example with custom fields:**
+
+```json
+{
+  "audit_id": "507f1f77bcf86cd799439011",
+  "title": "SQL Injection in Login Form",
+  "customFields": [
+    {
+      "customField": "65b135e5cc7f41163c9d4510",
+      "text": "CWE-89"
+    },
+    {
+      "customField": "61b76937cec3ca00128fe075",
+      "text": "Critical"
+    },
+    {
+      "customField": "61b768eacec3ca00128fe073",
+      "text": ["C", "I", "D"]
+    }
+  ]
+}
+```
+
+**Workflow to use custom fields:**
+
+1. Call `list_custom_fields` to get available fields with their IDs, types, and options
+2. Filter fields by `display: "vulnerability"` or `display: "finding"` for finding-related fields
+3. For `select` type fields, use one of the values from the `options` array
+4. For `select-multiple` or `checkbox` type fields, use an array of values from the `options` array
+5. Include the custom fields in your `create_finding` or `update_finding` call
 
 ### Examples
 
@@ -114,6 +155,29 @@ Same as `create_finding`, plus:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `finding_id` | string | Yes | The finding ID to update |
+
+### Updating Custom Fields
+
+You can update custom fields in the same way as when creating a finding. The `customFields` array will replace the existing custom fields.
+
+**Example - Update CWE and Impact Level:**
+
+```json
+{
+  "audit_id": "507f1f77bcf86cd799439011",
+  "finding_id": "507f1f77bcf86cd799439041",
+  "customFields": [
+    {
+      "customField": "65b135e5cc7f41163c9d4510",
+      "text": "CWE-79"
+    },
+    {
+      "customField": "61b76937cec3ca00128fe075",
+      "text": "Major"
+    }
+  ]
+}
+```
 
 ### Examples
 

--- a/python/src/pwndoc_mcp_server/server.py
+++ b/python/src/pwndoc_mcp_server/server.py
@@ -348,6 +348,23 @@ class PwnDocMCPServer:
                         "items": {"type": "string"},
                         "description": "References",
                     },
+                    "customFields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "customField": {
+                                    "type": "string",
+                                    "description": "Custom field ID (_id from list_custom_fields)",
+                                },
+                                "text": {
+                                    "description": "Value for the custom field. String for input/select/text fields, array of strings for select-multiple/checkbox fields",
+                                },
+                            },
+                            "required": ["customField", "text"],
+                        },
+                        "description": "Custom fields values. Each item must have 'customField' (the field ID) and 'text' (the value). Use list_custom_fields to get available fields and their IDs.",
+                    },
                 },
                 "required": ["audit_id", "title"],
             },
@@ -373,6 +390,23 @@ class PwnDocMCPServer:
                     "poc": {"type": "string"},
                     "scope": {"type": "string"},
                     "references": {"type": "array", "items": {"type": "string"}},
+                    "customFields": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "customField": {
+                                    "type": "string",
+                                    "description": "Custom field ID (_id from list_custom_fields)",
+                                },
+                                "text": {
+                                    "description": "Value for the custom field. String for input/select/text fields, array of strings for select-multiple/checkbox fields",
+                                },
+                            },
+                            "required": ["customField", "text"],
+                        },
+                        "description": "Custom fields values. Each item must have 'customField' (the field ID) and 'text' (the value). Use list_custom_fields to get available fields and their IDs.",
+                    },
                 },
                 "required": ["audit_id", "finding_id"],
             },
@@ -1374,9 +1408,15 @@ class PwnDocMCPServer:
         return self.client.get_finding(audit_id, finding_id)
 
     def _handle_create_finding(self, audit_id: str, **kwargs) -> Dict:
+        # Parse customFields if it's a string (can happen with some MCP clients)
+        if "customFields" in kwargs and isinstance(kwargs["customFields"], str):
+            kwargs["customFields"] = json.loads(kwargs["customFields"])
         return self.client.create_finding(audit_id, **kwargs)
 
     def _handle_update_finding(self, audit_id: str, finding_id: str, **kwargs) -> Dict:
+        # Parse customFields if it's a string (can happen with some MCP clients)
+        if "customFields" in kwargs and isinstance(kwargs["customFields"], str):
+            kwargs["customFields"] = json.loads(kwargs["customFields"])
         return self.client.update_finding(audit_id, finding_id, **kwargs)
 
     def _handle_delete_finding(self, audit_id: str, finding_id: str) -> Dict:


### PR DESCRIPTION
- Introduced `customFields` parameter in findings creation and update processes.
- Updated documentation to include details on how to use custom fields, including examples.
- Enhanced server code to handle `customFields` as an array of objects, ensuring proper parsing and validation.


Tested locally.